### PR TITLE
Fix TypeError in resolveTranslatedValue for JSON casted attributes

### DIFF
--- a/src/Traits/HasTranslations.php
+++ b/src/Traits/HasTranslations.php
@@ -123,7 +123,7 @@ trait HasTranslations
          : Str::snake(class_basename($this)) . '_' . $this->getKeyName();
    }
 
-   protected function resolveTranslatedValue(string $column, ?string $locale): mixed
+   protected function resolveTranslatedValue(string $column, ?string $locale): string|array|null
    {
       $localesToCheck = array_unique(
          array_filter([$locale, $this->getActiveLocale(), App::getLocale(), Config::get('translatable.fallback_locale')]),

--- a/src/Traits/HasTranslations.php
+++ b/src/Traits/HasTranslations.php
@@ -123,7 +123,7 @@ trait HasTranslations
          : Str::snake(class_basename($this)) . '_' . $this->getKeyName();
    }
 
-   protected function resolveTranslatedValue(string $column, ?string $locale): ?string
+   protected function resolveTranslatedValue(string $column, ?string $locale): mixed
    {
       $localesToCheck = array_unique(
          array_filter([$locale, $this->getActiveLocale(), App::getLocale(), Config::get('translatable.fallback_locale')]),


### PR DESCRIPTION
### Description
This PR fixes a `TypeError` that occurs when accessing JSON-translated attributes as described in the documentation.

### The Problem
When following the documentation for "Accessing JSON Translations" (setting `$allowJsonTranslationsFor` and casting the attribute to `array`), reading the attribute throws the following error:

`TypeError: App\Models\...::resolveTranslatedValue(): Return value must be of type ?string, array returned`

This happens because the `resolveTranslatedValue` method in the `HasTranslations` trait strictly defines `?string` as the return type. However, when a column is cast to an array, `$this->getOriginal($column)` or the resolved cached translation returns an `array`, causing the application to crash.

### The Solution
Updated the return type of `resolveTranslatedValue` from `?string` to `string|array|null`. 

This safely aligns with Laravel's dynamic attribute casting, allowing the method to return arrays for JSON translations while flawlessly preserving the default behavior for standard string translations.